### PR TITLE
ipvs/netlink.go: specify address family as an attribute

### DIFF
--- a/netlink.go
+++ b/netlink.go
@@ -110,7 +110,8 @@ func fillDestination(d *Destination) nl.NetlinkRequestData {
 	portBuf := new(bytes.Buffer)
 	binary.Write(portBuf, binary.BigEndian, d.Port)
 	nl.NewRtAttrChild(cmdAttr, ipvsDestAttrPort, portBuf.Bytes())
-
+	nl.NewRtAttrChild(cmdAttr, ipvsDestAttrAddressFamily, nl.Uint32Attr(uint32(d.AddressFamily)))
+	
 	nl.NewRtAttrChild(cmdAttr, ipvsDestAttrForwardingMethod, nl.Uint32Attr(d.ConnectionFlags&ConnectionFlagFwdMask))
 	nl.NewRtAttrChild(cmdAttr, ipvsDestAttrWeight, nl.Uint32Attr(uint32(d.Weight)))
 	nl.NewRtAttrChild(cmdAttr, ipvsDestAttrUpperThreshold, nl.Uint32Attr(d.UpperThreshold))


### PR DESCRIPTION
For IPv6 addresses we need to make sure that the address family is also passed in when filling the destination otherwise it will get parsed as a v4 address.